### PR TITLE
python-opensesame==3.1.7a8

### DIFF
--- a/python-opensesame/meta.yaml
+++ b/python-opensesame/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: python-opensesame
-  version: "3.1.7a7"
+  version: "3.1.7a8"
 
 source:
-  fn: python-opensesame-3.1.7a7.tar.gz
-  url: https://pypi.python.org/packages/ec/8f/b17513578afb98515692fe36764b99a1d8a9e6bef1b81f27b3cb31ba6fc4/python-opensesame-3.1.7a7.tar.gz
-  md5: 86bf18c3ddf2bd8147debd065fdf4319
+  fn: python-opensesame-3.1.7a8.tar.gz
+  url: https://pypi.python.org/packages/d0/c8/974841ea983588b0b4d4028df8c5e1b0d7d21cd816016fcf4cab43807af2/python-opensesame-3.1.7a8.tar.gz
+  md5: bbcbeacd336ed570200eb02ba483f753
 
 build:
   noarch_python: True


### PR DESCRIPTION
This should fix the issue with `connect()` not accepting any keywords. This was a regression that I hadn't noticed because only occurs on PyQt4, I think. Could you let me know if 3.1.7a8 can be tagged as stable as far as Mac OS is concerned?