### PR TITLE
Updates for 3.2.2

### DIFF
--- a/python-datamatrix/meta.yaml
+++ b/python-datamatrix/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: python-datamatrix
-  version: "0.8.1"
+  version: "0.8.3"
 
 source:
-  fn: python-datamatrix-0.8.1.tar.gz
-  url: https://pypi.python.org/packages/a6/56/89ac10042c4b128420f15d5c4f5f6d3b1dc6637934024c25a1536cc223d7/python-datamatrix-0.8.1.tar.gz
-  md5: 8e50d08d08b8d9a52a816dd149c45157
+  fn: python-datamatrix-0.8.3.tar.gz
+  url: https://pypi.python.org/packages/be/4a/82a8fa6b96a1c0e76402d9f5dc2ce9f23b9a8eea21eb27dfcd50da6b086d/python-datamatrix-0.8.3.tar.gz
+  md5: e24eab71e8f0d38c25fb0c26bf2f1651
 #  patches:
    # List any patch files here
    # - fix.patch

--- a/python-opensesame/meta.yaml
+++ b/python-opensesame/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: python-opensesame
-  version: "3.2.1"
+  version: "3.2.2"
 
 source:
-  fn: python-opensesame-3.2.1.tar.gz
-  url: https://pypi.python.org/packages/2e/bf/3a83d887a0b280ebd0321a1af2ee1219a6ba8caa4dbbe79128a1a22b5b1b/python-opensesame-3.2.1.tar.gz
-  md5: 3282bd59dbd03aac82b49cf3bfc21dca
+  fn: python-opensesame-3.2.2.tar.gz
+  url: https://pypi.python.org/packages/ac/c9/49b7750b2a821d3e3e89c17b5f9eb562c1f608323728c2d93a4d50296849/python-opensesame-3.2.2.tar.gz
+  md5: 17bab424cb6cc861006d7bff7ba697e2
 
 build:
   noarch_python: True

--- a/python-pygaze/meta.yaml
+++ b/python-pygaze/meta.yaml
@@ -1,11 +1,11 @@
 package:
   name: python-pygaze
-  version: "0.6.0a23"
+  version: "0.6.0a25"
 
 source:
-  fn: python-pygaze-0.6.0a23.tar.gz
-  url: https://pypi.python.org/packages/43/0a/c0e322ce6c70083c823121ca455e847151db097ac7125987f6d29ce1fe60/python-pygaze-0.6.0a23.tar.gz
-  md5: b7159c8c712eafc699151bb3fa0aff4b
+  fn: python-pygaze-0.6.0a25.tar.gz
+  url: https://pypi.python.org/packages/7d/9b/053c15bae5b2211d1264c08bb9a8f1f642a5231137c2de4e64579768e866/python-pygaze-0.6.0a25.tar.gz
+  md5: c56d3910df6ed776191e7a41c2321d2b
 
 build:
   noarch_python: True


### PR DESCRIPTION
These three packages need to be updated. For the Mac OS, `openpyxl` should also be included this time (it was missing from 3.2.1).